### PR TITLE
Fix exception with two-arity version of timer function on the jvm (issue #24)

### DIFF
--- a/src/beicon/core.cljc
+++ b/src/beicon/core.cljc
@@ -661,7 +661,7 @@
       :clj  (Observable/timer ^long delay TimeUnit/MILLISECONDS)))
   ([delay period]
    #?(:cljs (.timer Observable delay period)
-      :clj  (Observable/interval ^long delay ^long period))))
+      :clj  (Observable/interval ^long delay ^long period TimeUnit/MILLISECONDS))))
 
 (defn timeout
   "Returns the source observable sequence or the other

--- a/test/beicon/tests/test_core.cljc
+++ b/test/beicon/tests/test_core.cljc
@@ -139,9 +139,36 @@
      :clj
      (let [s (->> (s/timer 200)
                   (s/timeout 100 (s/just :timeout)))]
-
        (t/is (s/observable? s))
        (drain! s #(t/is (= % [:timeout]))))))
+
+(t/deftest observable-pause-from-timer
+  #?(:cljs
+     (t/async done
+      (let [s (s/timer 100)]
+        (t/is (s/observable? s))
+        (drain! s #(do
+                     (t/is (= % [0]))
+                     (s/on-end s done)))))
+     :clj
+     (let [s (s/timer 100)]
+       (t/is (s/observable? s))
+       (drain! s #(t/is (= % [0]))))))
+
+(t/deftest observable-interval-from-timer
+  #?(:cljs
+     (t/async done
+      (let [s (->> (s/timer 100 100)
+                   (s/take 2))]
+        (t/is (s/observable? s))
+        (drain! s #(do
+                     (t/is (= % [0 1]))
+                     (s/on-end s done)))))
+     :clj
+     (let [s (->> (s/timer 100 100)
+                  (s/take 2))]
+       (t/is (s/observable? s))
+       (drain! s #(t/is (= % [0 1]))))))
 
 (t/deftest observable-errors-from-create
   #?(:cljs


### PR DESCRIPTION
(rx/timer 100 100)
=>
ClassCastException java.lang.Long cannot be cast to
java.util.concurrent.TimeUnit  beicon.core/timer (core.cljc:656)

Resolved issue and wrote tests to cover timer function.