### PR TITLE
Fix typo in scheduler creation in cljs

### DIFF
--- a/src/beicon/core.cljc
+++ b/src/beicon/core.cljc
@@ -1169,12 +1169,12 @@
 #?(:cljs
    (defn scheduler
      "Get the scheduler instance by type.
-     The posible types are: `:asap`, `:queue`, `:async`."
+     The posible types are: `:asap`, `:async`, `:queue`."
      [type]
      (case type
-       :trampoline (.-queue Scheduler)
        :asap (.-asap Scheduler)
-       :async (.-async Scheduler)))
+       :async (.-async Scheduler)
+       :queue (.-queue Scheduler)))
    :clj
    (defn scheduler
      "Get the scheduler instance by type. The possible

--- a/src/beicon/core.cljc
+++ b/src/beicon/core.cljc
@@ -1169,12 +1169,14 @@
 #?(:cljs
    (defn scheduler
      "Get the scheduler instance by type.
-     The posible types are: `:asap`, `:async`, `:queue`."
+     The posible types are: `:asap`, `:async`, `:queue`.
+     Old `:trampoline` type is renamed as `:queue` and is deprecated."
      [type]
      (case type
        :asap (.-asap Scheduler)
        :async (.-async Scheduler)
-       :queue (.-queue Scheduler)))
+       :queue (.-queue Scheduler)
+       :trampoline (.-queue Scheduler)))
    :clj
    (defn scheduler
      "Get the scheduler instance by type. The possible

--- a/test/beicon/tests/test_core.cljc
+++ b/test/beicon/tests/test_core.cljc
@@ -630,7 +630,7 @@
   #?(:cljs
      (t/async done
        (let [coll [1 2 3]
-             s (s/subscribe-on :trampoline (s/from-coll coll))]
+             s (s/subscribe-on :queue (s/from-coll coll))]
          (t/is (s/observable? s))
          (drain! s #(t/is (= % coll)))
          (s/on-end s done)))


### PR DESCRIPTION
I believe there should be `:queue` instead of `:trampoline` as valid clause.