### PR TITLE
Fix typo

### DIFF
--- a/src/beicon/core.cljc
+++ b/src/beicon/core.cljc
@@ -112,7 +112,7 @@
   "Check if the provided object is disposable (jvm) or subscription (js)."
   [v]
   #?(:clj (instance? Disposable v)
-     :clj (instance? Subscription v)))
+     :cljs (instance? Subscription v)))
 
 #?(:clj
    (defn flowable?


### PR DESCRIPTION
Was reading the source today and noticed this little typo.  Likely since it was cljs specific, it was not creating a problem.