### PR TITLE
Add skip-last, concat-reduce, flatten

### DIFF
--- a/src/beicon/core.cljs
+++ b/src/beicon/core.cljs
@@ -476,6 +476,12 @@
   (let [merge-scan-fn (unchecked-get rxop "mergeScan")]
     (pipe ob (merge-scan-fn #(f %1 %2) seed))))
 
+(defn expand
+  "Recursively projects each source value to an Observable
+  which is merged in the output Observable."
+  [f ob]
+  (pipe ob (.expand ^js rxop f)))
+
 (defn with-latest
   "Merges the specified observable sequences into one observable
   sequence by using the selector function only when the source

--- a/src/beicon/core.cljs
+++ b/src/beicon/core.cljs
@@ -708,6 +708,11 @@
   [ms ob]
   (pipe ob (.delay ^js rxop ms)))
 
+(defn delay-emit
+  "Time shift the observable but also increase the relative time between emisions."
+  [ms ob]
+  (pipe ob (mapcat #(delay ms (of %)))))
+
 (defn delay-when
   "Time shifts the observable sequence based on a subscription
   delay and a delay selector function for each element."


### PR DESCRIPTION
New features:
- skip-last. Method that already exists in rxjs just exposing it
- flatten. Just like clojure's flatten but for Rx. Not standard but i think is convenient
- concat-reduce. This is a bit more tricky. I did my own implementation because merge-scan won't work as expected for asynchronous streams. This concat-reduce will wait until the resulting stream finishes before calculating the next step.